### PR TITLE
Do not override platform...

### DIFF
--- a/driver/CHANGELOG.md
+++ b/driver/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0
+- [FIX] Do not override platform when the `-p` is not passed.
+
 ## 1.0.1
 - Improving testability
 

--- a/driver/lib/src/driver_helper.dart
+++ b/driver/lib/src/driver_helper.dart
@@ -18,7 +18,8 @@ Future<String> configureTest(BaseConfiguration config) async {
   );
 
   final platform = config.platform.targetPlatform;
-  if (debugDefaultTargetPlatformOverride != platform) {
+  if (platform != TargetPlatform.fuchsia &&
+      debugDefaultTargetPlatformOverride != platform) {
     debugDefaultTargetPlatformOverride = platform;
   }
 

--- a/driver/pubspec.yaml
+++ b/driver/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fast_flutter_driver
 description: Toolkit for running rapidly flutter driver tests on desktop.
-version: 1.0.1
+version: 1.1.0
 homepage: https://github.com/tomaszpolanski/fast_flutter_driver
 
 environment:

--- a/driver/test/driver_helper_test.dart
+++ b/driver/test/driver_helper_test.dart
@@ -17,20 +17,42 @@ void main() {
     });
   });
   group('configureTest', () {
+    BaseConfiguration config;
+
+    setUp(() {
+      macOsOverride = false;
+      windowsOverride = false;
+      linuxOverride = true;
+      config = _MockConfiguration();
+      when(config.resolution).thenReturn(Resolution.fromSize('1x1'));
+    });
+
     tearDown(() {
       macOsOverride = null;
       windowsOverride = null;
+      linuxOverride = null;
     });
 
-    test('init', () async {
-      macOsOverride = false;
-      windowsOverride = false;
-      final config = _MockConfiguration();
-      when(config.resolution).thenReturn(Resolution.fromSize('1x1'));
+    group('platform', () {
+      test('when platform is not passed then do not override it', () async {
+        const platform = TargetPlatform.android;
+        debugDefaultTargetPlatformOverride = platform;
+        when(config.platform).thenReturn(null);
 
-      final tested = await configureTest(config);
+        await configureTest(config);
 
-      expect(tested, isNull);
+        expect(debugDefaultTargetPlatformOverride, platform);
+      });
+
+      test('when platform is passed then do override it', () async {
+        const platform = TestPlatform.android;
+        debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
+        when(config.platform).thenReturn(platform);
+
+        await configureTest(config);
+
+        expect(debugDefaultTargetPlatformOverride, platform.targetPlatform);
+      });
     });
   });
 }


### PR DESCRIPTION
when `-p` is not passed.
This prevents the platform to be overritten to fuchsia