### PR TITLE
[docs] rename main_test.dart to example_test.dart

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ void main() {
 }
 
 ```
-- Create a test, eg `test_driver/main_test.dart` 
+- Create a test, eg `test_driver/example_test.dart` 
 ```dart
 import 'dart:convert';
 


### PR DESCRIPTION
Hi there!

I'm playing around with this tool for a project of mine, and I ran into one issue with the docs. Thanks for this project! Seems really useful.

It's not safe to name the file `main_test.dart` because the generated test runner file will import that file's main function `as main` which conflicts with the `main` function in the generated test runner file. Took me a few minutes to figure this out when setting up a project.

It might also be useful to document that users should add `test_driver/generic/generic_test.dart` to their gitignore file, what do you think?