### PR TITLE
Allowing to extend flutter dart and test commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,13 +49,17 @@ jobs:
     strategy:
       matrix:
         package: ["driver"]
-        channel: ["dev", "beta"]
+        channel: ["beta", "stable"]
 
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
           channel: ${{ matrix.channel }}
+
+      - name: Install dependencies
+        run: flutter packages get
+        working-directory: ${{ matrix.package }}
 
       - name: Analyze
         run: dart analyze

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,6 @@ jobs:
         with:
           channel: ${{ matrix.channel }}
 
-      - name: Install dependencies
-        run: flutter packages get
-        working-directory: ${{ matrix.package }}
-
       - name: Analyze
         run: dart analyze
         working-directory: ${{ matrix.package }}

--- a/driver/CHANGELOG.md
+++ b/driver/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0
+- [FEATURE] Added `TestProperties::additionalArgs` that allows passing arguments to the tests. 
+If you want to implement passing for example language that the app should be run, then you can run `fastdriver --test-args "--language pl"`.
+Your tests will not receive in `TestProperties::additionalArgs` `--language pl` that can be used to set up your tests and app.
+
+
 ## 1.1.0+1
 - Updating example to Flutter `1.22.0-12.1.pre`
 

--- a/driver/analysis_options.yaml
+++ b/driver/analysis_options.yaml
@@ -151,7 +151,7 @@ linter:
     - slash_for_doc_comments
     - sort_child_properties_last
     - sort_constructors_first
-    - sort_pub_dependencies
+    # - sort_pub_dependencies # do not use it
     - sort_unnamed_constructors_first
     - test_types_in_equals
     - throw_in_finally

--- a/driver/pubspec.yaml
+++ b/driver/pubspec.yaml
@@ -5,7 +5,6 @@ homepage: https://github.com/tomaszpolanski/fast_flutter_driver
 
 environment:
   sdk: '>=2.6.0 <3.0.0'
-  flutter: ">=1.12.8 <2.0.0"
 
 dependencies:
   flutter:

--- a/driver/pubspec.yaml
+++ b/driver/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.2.0
 homepage: https://github.com/tomaszpolanski/fast_flutter_driver
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: '>=2.10.0 <3.0.0'
   flutter: ">=1.12.8 <2.0.0"
 
 dependencies:

--- a/driver/pubspec.yaml
+++ b/driver/pubspec.yaml
@@ -4,7 +4,8 @@ version: 1.2.0
 homepage: https://github.com/tomaszpolanski/fast_flutter_driver
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: ">=2.10.0 <3.0.0"
+  flutter: ">=1.12.8 <2.0.0"
 
 dependencies:
   flutter:

--- a/driver/pubspec.yaml
+++ b/driver/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   args: ^1.5.1
   colorize: ^2.0.0
   csv: ^4.0.0
-  fast_flutter_driver_tool: ^1.3.2+1
+  fast_flutter_driver_tool: ^1.4.0
   meta: ^1.1.8
   mockito: ^4.1.1
   process_run: ^0.10.0+1

--- a/driver/pubspec.yaml
+++ b/driver/pubspec.yaml
@@ -1,10 +1,10 @@
 name: fast_flutter_driver
 description: Toolkit for running rapidly flutter driver tests on desktop.
-version: 1.1.0+1
+version: 1.2.0
 homepage: https://github.com/tomaszpolanski/fast_flutter_driver
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.10.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/driver/pubspec.yaml
+++ b/driver/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.2.0
 homepage: https://github.com/tomaszpolanski/fast_flutter_driver
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
   flutter: ">=1.12.8 <2.0.0"
 
 dependencies:

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -152,7 +152,7 @@ linter:
     - slash_for_doc_comments
     - sort_child_properties_last
     - sort_constructors_first
-    - sort_pub_dependencies
+    # - sort_pub_dependencies # do not use it
     - sort_unnamed_constructors_first
     - test_types_in_equals
     - throw_in_finally

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: An example on how to use Fast Flutter Driver
 version: 1.0.0+1
 
 environment:
-sdk: '>=2.10.0 <3.0.0'
+  sdk: ">=2.6.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.8 <2.0.0"
 
 dependencies:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: An example on how to use Fast Flutter Driver
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: '>=2.10.0 <3.0.0'
   flutter: ">=1.12.13+hotfix.8 <2.0.0"
 
 dependencies:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: An example on how to use Fast Flutter Driver
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+sdk: '>=2.10.0 <3.0.0'
   flutter: ">=1.12.13+hotfix.8 <2.0.0"
 
 dependencies:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: An example on how to use Fast Flutter Driver
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.8 <2.0.0"
 
 dependencies:

--- a/tool/CHANGELOG.md
+++ b/tool/CHANGELOG.md
@@ -1,5 +1,12 @@
+## 1.4.0
+- [FEATURE] Allowing to pass additional arguments to `flutter run` command via `--flutter-args` command eg `fastdriver --flutter-args --enable-experiment:non-nullable`
+- [FEATURE] Allowing to pass additional arguments to `dart` command via `--dart-args` command eg `fastdriver --dart-args --enable-experiment=non-nullable`
+- [FEATURE] Allowing to pass additional arguments to tests. 
+If you want to implement passing for example language that the app should be run, then you can run `fastdriver --test-args "--language pl"`.
+Your tests will not receive in `TestProperties::additionalArgs` `--language pl` that can be used to set up your tests and app.
+
 ## 1.3.3
-- Tests in `generic_test.dart::main` are sorted by name in case users want to run the tests in a specific order
+- [FEATURE] Tests in `generic_test.dart::main` are sorted by name in case users want to run the tests in a specific order
 
 ## 1.3.2+1
 - Updating example to Flutter `1.22.0-12.1.pre`

--- a/tool/analysis_options.yaml
+++ b/tool/analysis_options.yaml
@@ -151,7 +151,7 @@ linter:
     - slash_for_doc_comments
     - sort_child_properties_last
     - sort_constructors_first
-    - sort_pub_dependencies
+    # - sort_pub_dependencies # do not use it
     - sort_unnamed_constructors_first
     - test_types_in_equals
     - throw_in_finally

--- a/tool/bin/main.dart
+++ b/tool/bin/main.dart
@@ -110,6 +110,7 @@ Future<void> run(
           flavor: result[flavorArg],
           flutterArguments: result[flutterArg],
           dartArguments: result[dartArg],
+          testArguments: result[testArg],
         ),
       ),
       logger: logger,

--- a/tool/bin/main.dart
+++ b/tool/bin/main.dart
@@ -108,6 +108,8 @@ Future<void> run(
           platform: TestPlatformEx.fromString(result[platformArg]),
           device: result[deviceArg],
           flavor: result[flavorArg],
+          flutterArguments: result[flutterArg],
+          dartArguments: result[dartArg],
         ),
       ),
       logger: logger,

--- a/tool/lib/src/preparing_tests/commands.dart
+++ b/tool/lib/src/preparing_tests/commands.dart
@@ -11,20 +11,31 @@ class FlutterCommand {
     String target,
     String device, {
     @required String flavor,
+    String additionalArguments,
   }) {
     // ignore: missing_whitespace_between_adjacent_strings
     return 'flutter run -d $device --target=$target'
-        '${flavor != null ? ' --flavor $flavor' : ''}';
+        '${flavor != null ? ' --flavor $flavor' : ''}'
+        '${additionalArguments != null ? ' $additionalArguments' : ''}';
   }
 
   String attach(String debugUri, String device) =>
       'flutter attach -d $device --debug-uri $debugUri';
 
-  String dart(String file, [Map<String, String> arguments]) {
-    final args = arguments?.entries
+  String dart(
+    String file, {
+    Map<String, String> testArguments,
+    String dartArguments,
+  }) {
+    final args = testArguments?.entries
         ?.map((entry) =>
             '${entry.key}${entry.value.isNotEmpty ? ' ${entry.value}' : ''}')
         ?.join(' ');
-    return 'dart $file ${args ?? ''}';
+
+    return 'dart'
+        '${dartArguments != null ? ' $dartArguments' : ''}'
+        // ignore: missing_whitespace_between_adjacent_strings
+        ' $file'
+        '${args != null ? ' $args' : ''}';
   }
 }

--- a/tool/lib/src/preparing_tests/parameters.dart
+++ b/tool/lib/src/preparing_tests/parameters.dart
@@ -19,6 +19,7 @@ const verboseArg = 'verbose';
 const versionArg = 'version';
 const flutterArg = 'flutter-args';
 const dartArg = 'dart-args';
+const testArg = 'test-args';
 
 ArgParser scriptParameters = ArgParser()
   ..addOption(
@@ -56,13 +57,20 @@ Supports the use of product flavors in Android Gradle scripts, and the use of cu
   ..addOption(
     flutterArg,
     help: '''
-Arguments to be passed while running the app via `flutter run`
+Arguments to be passed while running the app via `flutter run`.
 ''',
   )
   ..addOption(
     dartArg,
     help: '''
-Arguments to be passed to dart while running test file
+Arguments to be passed to dart while running test file.
+''',
+  )
+  ..addOption(
+    testArg,
+    help: '''
+Additional arguments to be passed to the test. 
+This is used to extend test functionality and this value will be passed as `TestProperties::additionalArgs`.
 ''',
   )
   ..addFlag(

--- a/tool/lib/src/preparing_tests/parameters.dart
+++ b/tool/lib/src/preparing_tests/parameters.dart
@@ -17,6 +17,8 @@ const deviceArg = 'device';
 const flavorArg = 'flavor';
 const verboseArg = 'verbose';
 const versionArg = 'version';
+const flutterArg = 'flutter-args';
+const dartArg = 'dart-args';
 
 ArgParser scriptParameters = ArgParser()
   ..addOption(
@@ -49,6 +51,18 @@ ArgParser scriptParameters = ArgParser()
     help: '''
 Build a custom app flavor as defined by platform-specific build setup.
 Supports the use of product flavors in Android Gradle scripts, and the use of custom Xcode schemes.
+''',
+  )
+  ..addOption(
+    flutterArg,
+    help: '''
+Arguments to be passed while running the app via `flutter run`
+''',
+  )
+  ..addOption(
+    dartArg,
+    help: '''
+Arguments to be passed to dart while running test file
 ''',
   )
   ..addFlag(

--- a/tool/lib/src/preparing_tests/parameters.dart
+++ b/tool/lib/src/preparing_tests/parameters.dart
@@ -65,7 +65,7 @@ Supports the use of product flavors in Android Gradle scripts, and the use of cu
   ..addFlag(
     verboseArg,
     abbr: verboseArg[0],
-    help: 'Show verbose loggin',
+    help: 'Show verbose logs',
     negatable: false,
   )
   ..addFlag(

--- a/tool/lib/src/preparing_tests/testing.dart
+++ b/tool/lib/src/preparing_tests/testing.dart
@@ -39,6 +39,8 @@ class ExecutorParameters {
     @required this.language,
     @required this.device,
     @required this.platform,
+    this.flutterArguments,
+    this.dartArguments,
     this.flavor,
   });
 
@@ -48,6 +50,8 @@ class ExecutorParameters {
   final String device;
   final TestPlatform platform;
   final String flavor;
+  final String flutterArguments;
+  final String dartArguments;
 }
 
 class TestExecutor {
@@ -76,6 +80,7 @@ class TestExecutor {
               mainFile,
               parameters.device,
               flavor: parameters.flavor,
+              additionalArguments: parameters.flutterArguments,
             ),
         input,
         outputFactory,
@@ -84,14 +89,18 @@ class TestExecutor {
         parameters.device,
       );
 
-      final runTestCommand = Commands().flutter.dart(testFile, testArguments: {
-        '-u': url,
-        if (parameters.withScreenshots) '-${screenshotsArg[0]}': '',
-        '-${resolutionArg[0]}': parameters.resolution,
-        '-${languageArg[0]}': parameters.language,
-        if (parameters.platform != null)
-          '-${platformArg[0]}': fromEnum(parameters.platform),
-      });
+      final runTestCommand = Commands().flutter.dart(
+        testFile,
+        dartArguments: parameters.dartArguments,
+        testArguments: {
+          '-u': url,
+          if (parameters.withScreenshots) '-${screenshotsArg[0]}': '',
+          '-${resolutionArg[0]}': parameters.resolution,
+          '-${languageArg[0]}': parameters.language,
+          if (parameters.platform != null)
+            '-${platformArg[0]}': fromEnum(parameters.platform),
+        },
+      );
 
       try {
         await _runTests(runTestCommand, outputFactory, run, logger);

--- a/tool/lib/src/preparing_tests/testing.dart
+++ b/tool/lib/src/preparing_tests/testing.dart
@@ -84,7 +84,7 @@ class TestExecutor {
         parameters.device,
       );
 
-      final runTestCommand = Commands().flutter.dart(testFile, {
+      final runTestCommand = Commands().flutter.dart(testFile, testArguments: {
         '-u': url,
         if (parameters.withScreenshots) '-${screenshotsArg[0]}': '',
         '-${resolutionArg[0]}': parameters.resolution,

--- a/tool/lib/src/preparing_tests/testing.dart
+++ b/tool/lib/src/preparing_tests/testing.dart
@@ -41,6 +41,7 @@ class ExecutorParameters {
     @required this.platform,
     this.flutterArguments,
     this.dartArguments,
+    this.testArguments,
     this.flavor,
   });
 
@@ -52,6 +53,7 @@ class ExecutorParameters {
   final String flavor;
   final String flutterArguments;
   final String dartArguments;
+  final String testArguments;
 }
 
 class TestExecutor {
@@ -99,6 +101,8 @@ class TestExecutor {
           '-${languageArg[0]}': parameters.language,
           if (parameters.platform != null)
             '-${platformArg[0]}': fromEnum(parameters.platform),
+          if (parameters.testArguments != null)
+            '--$testArg': parameters.testArguments,
         },
       );
 

--- a/tool/lib/src/preparing_tests/testing.dart
+++ b/tool/lib/src/preparing_tests/testing.dart
@@ -102,7 +102,7 @@ class TestExecutor {
           if (parameters.platform != null)
             '-${platformArg[0]}': fromEnum(parameters.platform),
           if (parameters.testArguments != null)
-            '--$testArg': parameters.testArguments,
+            '--$testArg': '"${parameters.testArguments}"',
         },
       );
 

--- a/tool/lib/src/running_tests/parameters.dart
+++ b/tool/lib/src/running_tests/parameters.dart
@@ -30,6 +30,10 @@ ArgParser testParameters = ArgParser()
     platformArg,
     abbr: platformArg[0],
     help: 'Overwritten platform of the device',
+  )
+  ..addOption(
+    testArg,
+    help: 'Additional parameters passed from the fastdriver',
   );
 
 /// UI platform for the application

--- a/tool/lib/src/running_tests/test_properties.dart
+++ b/tool/lib/src/running_tests/test_properties.dart
@@ -34,6 +34,11 @@ class TestProperties {
   /// passes it.
   TestPlatform get platform =>
       TestPlatformEx.fromString(arguments[platformArg]);
+
+  /// Additional parameters passed via --test-args from fastdriver.
+  /// This is used to extend the capabilities of your tests without the need
+  /// of modifying fastdriver's code.
+  String get additionalArgs => arguments[testArg];
 }
 
 /// Base configuration that will be passed from tests to the application

--- a/tool/pubspec.lock
+++ b/tool/pubspec.lock
@@ -394,4 +394,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.7.0 <3.0.0"
+  dart: ">=2.10.0 <3.0.0"

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fast_flutter_driver_tool
 description: Toolkit for running rapidly flutter driver tests on desktop.
-version: 1.3.3
+version: 1.4.0
 homepage: https://github.com/tomaszpolanski/fast_flutter_driver
 
 environment:

--- a/tool/test/main_lib_test.dart
+++ b/tool/test/main_lib_test.dart
@@ -86,7 +86,6 @@ void main() {
       linuxOverride = false;
       when(versionChecker.checkForUpdates()).thenAnswer((_) async => null);
       when(testFileProvider.testFile(any)).thenAnswer((_) async => 'any');
-      const flavor = 'chocolate';
 
       await main_file.run(
         ['--flutter-args', arguments],
@@ -120,6 +119,26 @@ void main() {
         testExecutor.test(any, parameters: captureAnyNamed('parameters')),
       ).captured.single;
       expect(parameters.dartArguments, arguments);
+    });
+
+    test('additional test arguments', () async {
+      const arguments = 'special-arguments-that-will-be-passed-to-the-test';
+      linuxOverride = false;
+      when(versionChecker.checkForUpdates()).thenAnswer((_) async => null);
+      when(testFileProvider.testFile(any)).thenAnswer((_) async => 'any');
+
+      await main_file.run(
+        ['--test-args', arguments],
+        loggerFactory: (_) => logger,
+        versionCheckerFactory: (_) => versionChecker,
+        testExecutorFactory: (_) => testExecutor,
+        testFileProviderFactory: (_) => testFileProvider,
+      );
+
+      final ExecutorParameters parameters = verify(
+        testExecutor.test(any, parameters: captureAnyNamed('parameters')),
+      ).captured.single;
+      expect(parameters.testArguments, arguments);
     });
 
     test('invalid command displays help', () async {

--- a/tool/test/main_lib_test.dart
+++ b/tool/test/main_lib_test.dart
@@ -81,6 +81,47 @@ void main() {
       expect(parameters.flavor, flavor);
     });
 
+    test('flutter arguments', () async {
+      const arguments = '--device-user=10 --host-vmservice-port';
+      linuxOverride = false;
+      when(versionChecker.checkForUpdates()).thenAnswer((_) async => null);
+      when(testFileProvider.testFile(any)).thenAnswer((_) async => 'any');
+      const flavor = 'chocolate';
+
+      await main_file.run(
+        ['--flutter-args', arguments],
+        loggerFactory: (_) => logger,
+        versionCheckerFactory: (_) => versionChecker,
+        testExecutorFactory: (_) => testExecutor,
+        testFileProviderFactory: (_) => testFileProvider,
+      );
+
+      final ExecutorParameters parameters = verify(
+        testExecutor.test(any, parameters: captureAnyNamed('parameters')),
+      ).captured.single;
+      expect(parameters.flutterArguments, arguments);
+    });
+
+    test('dart arguments', () async {
+      const arguments = '--enable-experiment=non-nullable';
+      linuxOverride = false;
+      when(versionChecker.checkForUpdates()).thenAnswer((_) async => null);
+      when(testFileProvider.testFile(any)).thenAnswer((_) async => 'any');
+
+      await main_file.run(
+        ['--dart-args', arguments],
+        loggerFactory: (_) => logger,
+        versionCheckerFactory: (_) => versionChecker,
+        testExecutorFactory: (_) => testExecutor,
+        testFileProviderFactory: (_) => testFileProvider,
+      );
+
+      final ExecutorParameters parameters = verify(
+        testExecutor.test(any, parameters: captureAnyNamed('parameters')),
+      ).captured.single;
+      expect(parameters.dartArguments, arguments);
+    });
+
     test('invalid command displays help', () async {
       const unknownCommand = 'this-is-unknown-command';
       await main_file.run(

--- a/tool/test/preparing_tests/commands_test.dart
+++ b/tool/test/preparing_tests/commands_test.dart
@@ -17,6 +17,17 @@ void main() {
             Commands().flutter.run(testFile, 'some_device', flavor: flavor);
         expect(tested, contains('--flavor $flavor'));
       });
+
+      test('passes additional arguments if available', () {
+        const arguments = '--device-user=10 --host-vmservice-port';
+        final tested = Commands().flutter.run(
+              testFile,
+              'some_device',
+              flavor: null,
+              additionalArguments: arguments,
+            );
+        expect(tested, contains(arguments));
+      });
     });
 
     group('attach', () {
@@ -33,16 +44,27 @@ void main() {
       test('when no parameters', () {
         final tested = Commands().flutter.dart(testFile);
 
-        expect(tested, 'dart $testFile ');
+        expect(tested, 'dart $testFile');
       });
 
       test('with parameters', () {
-        final tested = Commands().flutter.dart(testFile, {
+        final tested = Commands().flutter.dart(testFile, testArguments: {
           '-u': 'u',
           '-s': '',
         });
 
         expect(tested, 'dart $testFile -u u -s');
+      });
+
+      test('with dart parameters', () {
+        const dartArgs = '--enable-experiment=non-nullable';
+
+        final tested = Commands().flutter.dart(
+              testFile,
+              dartArguments: dartArgs,
+            );
+
+        expect(tested, 'dart $dartArgs $testFile');
       });
     });
   });

--- a/tool/test/preparing_tests/testing_test.dart
+++ b/tool/test/preparing_tests/testing_test.dart
@@ -123,6 +123,46 @@ void main() {
       );
     });
 
+    test('passes flutter arguments', () {
+      const arguments = '--device-user=10 --host-vmservice-port';
+      final commands = <String>[];
+      tested = test_executor.TestExecutor(
+        outputFactory: streams.output,
+        inputFactory: streams.input,
+        run: (
+          String command, {
+          streams.OutputCommandLineStream stdout,
+          streams.InputCommandLineStream stdin,
+          streams.OutputCommandLineStream stderr,
+        }) async {
+          commands.add(command);
+        },
+        logger: logger,
+      );
+
+      // ignore: cascade_invocations
+      tested.test(
+        'generic_test.dart',
+        parameters: test_executor.ExecutorParameters(
+          withScreenshots: false,
+          language: 'pl',
+          resolution: '800x600',
+          platform: TestPlatform.android,
+          device: devices.device,
+          flutterArguments: arguments,
+        ),
+      );
+
+      expect(
+        commands,
+        contains(
+          'flutter run -d ${devices.device} '
+          '--target=generic.dart '
+          '$arguments',
+        ),
+      );
+    });
+
     test('builds application for specific device', () {
       final commands = <String>[];
       const device = 'some_special_device';
@@ -195,6 +235,49 @@ void main() {
         commands,
         contains(
             'dart generic_test.dart -u http://127.0.0.1:50512/CKxutzePXlo/ -r 800x600 -l pl -p android'),
+      );
+    });
+
+    test('passes dart arguments', () async {
+      const dartArgs = '--enable-experiment=non-nullable';
+      final commands = <String>[];
+      tested = test_executor.TestExecutor(
+        outputFactory: streams.output,
+        inputFactory: () => _MockInputCommandLineStream(),
+        run: (
+          String command, {
+          streams.OutputCommandLineStream stdout,
+          streams.InputCommandLineStream stdin,
+          streams.OutputCommandLineStream stderr,
+        }) async {
+          commands.add(command);
+          if (command ==
+              'flutter run -d ${devices.device} --target=generic.dart') {
+            stdout.stream.add(
+              utf8.encode(
+                  'is available at: http://127.0.0.1:50512/CKxutzePXlo/'),
+            );
+          }
+        },
+        logger: logger,
+      );
+      await tested.test(
+        'generic_test.dart',
+        parameters: test_executor.ExecutorParameters(
+          withScreenshots: false,
+          language: 'pl',
+          resolution: '800x600',
+          platform: TestPlatform.android,
+          device: devices.device,
+          dartArguments: dartArgs,
+        ),
+      );
+
+      expect(
+        commands,
+        contains(
+          'dart $dartArgs generic_test.dart -u http://127.0.0.1:50512/CKxutzePXlo/ -r 800x600 -l pl -p android',
+        ),
       );
     });
   });

--- a/tool/test/preparing_tests/testing_test.dart
+++ b/tool/test/preparing_tests/testing_test.dart
@@ -282,7 +282,7 @@ void main() {
     });
 
     test('passes test arguments', () async {
-      const testArgs = 'additional-arguments';
+      const testArgs = 'additional arguments';
       final commands = <String>[];
       tested = test_executor.TestExecutor(
         outputFactory: streams.output,
@@ -319,7 +319,7 @@ void main() {
       expect(
         commands,
         contains(
-          'dart generic_test.dart -u http://127.0.0.1:50512/CKxutzePXlo/ -r 800x600 -l pl -p android --test-args $testArgs',
+          'dart generic_test.dart -u http://127.0.0.1:50512/CKxutzePXlo/ -r 800x600 -l pl -p android --test-args "$testArgs"',
         ),
       );
     });

--- a/tool/test/preparing_tests/testing_test.dart
+++ b/tool/test/preparing_tests/testing_test.dart
@@ -280,6 +280,49 @@ void main() {
         ),
       );
     });
+
+    test('passes test arguments', () async {
+      const testArgs = 'additional-arguments';
+      final commands = <String>[];
+      tested = test_executor.TestExecutor(
+        outputFactory: streams.output,
+        inputFactory: () => _MockInputCommandLineStream(),
+        run: (
+          String command, {
+          streams.OutputCommandLineStream stdout,
+          streams.InputCommandLineStream stdin,
+          streams.OutputCommandLineStream stderr,
+        }) async {
+          commands.add(command);
+          if (command ==
+              'flutter run -d ${devices.device} --target=generic.dart') {
+            stdout.stream.add(
+              utf8.encode(
+                  'is available at: http://127.0.0.1:50512/CKxutzePXlo/'),
+            );
+          }
+        },
+        logger: logger,
+      );
+      await tested.test(
+        'generic_test.dart',
+        parameters: test_executor.ExecutorParameters(
+          withScreenshots: false,
+          language: 'pl',
+          resolution: '800x600',
+          platform: TestPlatform.android,
+          device: devices.device,
+          testArguments: testArgs,
+        ),
+      );
+
+      expect(
+        commands,
+        contains(
+          'dart generic_test.dart -u http://127.0.0.1:50512/CKxutzePXlo/ -r 800x600 -l pl -p android --test-args $testArgs',
+        ),
+      );
+    });
   });
 }
 

--- a/tool/test/running_tests/test_properties_test.dart
+++ b/tool/test/running_tests/test_properties_test.dart
@@ -1,0 +1,13 @@
+import 'package:fast_flutter_driver_tool/src/running_tests/test_properties.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TestProperties', () {
+    test('additionalArgs', () {
+      const arguments = 'special-arguments-that-will-be-passed-to-the-test';
+      final tested = TestProperties(['--test-args', arguments]).additionalArgs;
+
+      expect(tested, arguments);
+    });
+  });
+}


### PR DESCRIPTION
#75 
Enabling passing additional arguments to `flutter run`, `dart` and tests itself